### PR TITLE
Update dependencies for newer version of minimatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
   "license": "MIT",
   "dependencies": {
     "handlebars": "^2.0.0",
-    "glob": "^3.2.9"
+    "glob": "^7.0.5"
   },
   "devDependencies": {
-    "mocha": "~2.3",
+    "mocha": "~3.0.0-0",
     "koa": "^0.5.5",
     "supertest": "^0.11.0",
     "koa-router": "^3.1.3",


### PR DESCRIPTION
As discussed in #49, some of koa-hbs dependencies depend on an outdated version of minimatch. The latter has a security vulnerability in versions below 3.0.2. I've updated glob and mocha to the latest versions to get minimatch@3.0.2. Tests run fine when executing `npm run-script test`.